### PR TITLE
Changes to the excel-import and -export function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "react-firebase-hooks": "^5.1.1",
         "react-helmet-async": "^2.0.5",
         "react-router-dom": "^6.22.2",
-        "tinymce": "^7.2.1"
+        "showdown": "^2.1.0",
+        "tinymce": "^7.2.1",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.56",
@@ -1724,6 +1726,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
     "node_modules/@mui/base": {
       "version": "5.0.0-beta.37",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.37.tgz",
@@ -2950,6 +2957,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/compress-commons": {
       "version": "4.1.2",
@@ -5834,6 +5849,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
@@ -6064,6 +6094,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7827,6 +7865,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
     "@mui/base": {
       "version": "5.0.0-beta.37",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.37.tgz",
@@ -8643,6 +8686,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
     },
     "compress-commons": {
       "version": "4.1.2",
@@ -10799,6 +10847,14 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "requires": {
+        "commander": "^9.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
@@ -10969,6 +11025,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "requires": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "react-firebase-hooks": "^5.1.1",
     "react-helmet-async": "^2.0.5",
     "react-router-dom": "^6.22.2",
-    "tinymce": "^7.2.1"
+    "showdown": "^2.1.0",
+    "tinymce": "^7.2.1",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.56",

--- a/src/pages/simulations/Edit/import/Download.jsx
+++ b/src/pages/simulations/Edit/import/Download.jsx
@@ -37,6 +37,21 @@ Bitte wählen Sie eine der folgenden Optionen:
 
 *Hinweis*: Dies ist ein _wichtiger_ Hinweis.
 		</pre>
+		<h4>Antwortmöglichkeiten</h4>
+		<p>Die Antwortmöglichkeiten für jede Frage werden in der Spalte "Antwortmöglichkeiten" gespeichert. Jede Antwortmöglichkeit wird in einer neuen Zeile angegeben und hat das folgende Format:</p>
+		<pre>Beschreibung|Rückmeldung|Folgeseite</pre>
+		<p>Wobei:</p>
+		<ul>
+			<li><strong>Beschreibung</strong>: Der Text der Antwortmöglichkeit (in Markdown-Format)</li>
+			<li><strong>Rückmeldung</strong>: Die Rückmeldung, die angezeigt wird, wenn diese Option gewählt wird (in Markdown-Format)</li>
+			<li><strong>Folgeseite</strong>: Die ID der nächsten Seite (optional)</li>
+		</ul>
+		<p>Beispiel:</p>
+		<pre>
+**Ja, ich stimme zu**|Danke für Ihre Zustimmung!|next_page_id
+**Nein, ich lehne ab**|Das ist schade.|end
+		</pre>
+		<p>Sie können die Rückmeldung und Folgeseite weglassen, indem Sie einfach nichts nach dem | eingeben.</p>
 	</>
 }
 

--- a/src/pages/simulations/Edit/import/Download.jsx
+++ b/src/pages/simulations/Edit/import/Download.jsx
@@ -14,6 +14,29 @@ export function Download({ simulation }) {
 			<li>Wenn Sie ein neues Element wie eine neue Seite hinzufügen möchten, lassen Sie die ID leer. Wir werden beim Importieren eine ID generieren. (Sie können sich auch eine eigene ID ausdenken, aber das ist nicht empfehlenswert.)</li>
 			<li>Die ID wird auch für Links verwendet, z. B. welche Seite sich in welchem Ordner befindet. Wenn Sie Ihre eigenen Links einrichten wollen, können Sie auch hier die ID verwenden, oder Sie können die Zeilennummer der Excel-Datei verwenden. Beim Importieren werden die Zeilennummern dann durch die richtige ID ersetzt.</li>
 		</ul>
+		<h4>Formatierung von Texten</h4>
+		<p>Die Texte in den Beschreibungen werden in Markdown-Format gespeichert. Hier sind die wichtigsten Formatierungsmöglichkeiten:</p>
+		<ul>
+			<li><strong>Fett</strong>: Verwenden Sie <code>**Text**</code> oder <code>__Text__</code></li>
+			<li><em>Kursiv</em>: Verwenden Sie <code>*Text*</code> oder <code>_Text_</code></li>
+			<li>Listen: Verwenden Sie <code>- </code> oder <code>* </code> am Anfang jeder Zeile</li>
+			<li>Nummerierte Listen: Verwenden Sie <code>1. </code>, <code>2. </code> usw.</li>
+			<li>Links: Verwenden Sie <code>[Linktext](URL)</code></li>
+			<li>Zeilenumbrüche: Fügen Sie zwei Leerzeichen am Ende der Zeile ein</li>
+			<li>Absätze: Lassen Sie eine Leerzeile zwischen den Absätzen</li>
+		</ul>
+		<p>Beispiel:</p>
+		<pre>
+**Wichtige Frage**
+
+Bitte wählen Sie eine der folgenden Optionen:
+
+1. Erste Option
+2. Zweite Option
+3. Dritte Option
+
+*Hinweis*: Dies ist ein _wichtiger_ Hinweis.
+		</pre>
 	</>
 }
 

--- a/src/pages/simulations/Edit/import/Download.jsx
+++ b/src/pages/simulations/Edit/import/Download.jsx
@@ -39,19 +39,38 @@ Bitte wählen Sie eine der folgenden Optionen:
 		</pre>
 		<h4>Antwortmöglichkeiten</h4>
 		<p>Die Antwortmöglichkeiten für jede Frage werden in der Spalte "Antwortmöglichkeiten" gespeichert. Jede Antwortmöglichkeit wird in einer neuen Zeile angegeben und hat das folgende Format:</p>
-		<pre>Beschreibung|Rückmeldung|Folgeseite</pre>
+		<pre>Beschreibung|Rückmeldung|Folgeseite|UpdateScript</pre>
 		<p>Wobei:</p>
 		<ul>
 			<li><strong>Beschreibung</strong>: Der Text der Antwortmöglichkeit (in Markdown-Format)</li>
 			<li><strong>Rückmeldung</strong>: Die Rückmeldung, die angezeigt wird, wenn diese Option gewählt wird (in Markdown-Format)</li>
 			<li><strong>Folgeseite</strong>: Die ID der nächsten Seite (optional)</li>
+			<li><strong>UpdateScript</strong>: Das Skript, das die Parameter aktualisiert, wenn diese Option ausgewählt wird</li>
 		</ul>
 		<p>Beispiel:</p>
 		<pre>
-**Ja, ich stimme zu**|Danke für Ihre Zustimmung!|next_page_id
-**Nein, ich lehne ab**|Das ist schade.|end
+**Ja, ich stimme zu**|Danke für Ihre Zustimmung!|next_page_id|score = score + 10
+**Nein, ich lehne ab**|Das ist schade.|end|score = score - 5
 		</pre>
-		<p>Sie können die Rückmeldung und Folgeseite weglassen, indem Sie einfach nichts nach dem | eingeben.</p>
+		<p>Sie können die Rückmeldung, Folgeseite und das UpdateScript weglassen, indem Sie einfach nichts nach dem | eingeben.</p>
+		
+		<h4>Parameter</h4>
+		<p>Die Excel-Datei enthält auch einen separaten Tab für Parameter, in dem Sie die Parameter (Variablen) der Simulation bearbeiten können. Jeder Parameter hat folgende Felder:</p>
+		<ul>
+			<li><strong>ID</strong>: Die eindeutige Kennung des Parameters (nicht ändern für bestehende Parameter)</li>
+			<li><strong>Name</strong>: Der Name des Parameters, wie er in Skripten verwendet wird (z.B. "score" oder "hp")</li>
+			<li><strong>Beschreibung</strong>: Der Anzeigename/Titel des Parameters</li>
+			<li><strong>Standardwert</strong>: Der Anfangswert des Parameters</li>
+			<li><strong>Minimalwert</strong>: Der minimale Wert für den Parameter (optional)</li>
+			<li><strong>Maximalwert</strong>: Der maximale Wert für den Parameter (optional)</li>
+		</ul>
+		<p>Beispiel für einen Parameter:</p>
+		<pre>
+ID            | Name  | Beschreibung     | Standardwert | Minimalwert | Maximalwert
+------------- | ----- | ---------------- | ------------ | ----------- | -----------
+(leer für neu)| score | Spielerpunktzahl | 0            | 0           | 100
+		</pre>
+		<p>Parameter können in Update-Skripten für Antwortoptionen verwendet werden und in Texten angezeigt werden.</p>
 	</>
 }
 

--- a/src/pages/simulations/Edit/import/Upload.jsx
+++ b/src/pages/simulations/Edit/import/Upload.jsx
@@ -86,12 +86,60 @@ function WorkbookReport({ simulation, workbook, setWorkbook, setApplied }) {
 }
 
 function ProcessedWorkbookReport({ simulation, processedWorkbook, setWorkbook, setApplied }) {
+	// Add a test function to verify Firebase updates work
+	const testParameterUpdate = async () => {
+		try {
+			console.log("Testing direct parameter update...")
+			const { db } = await import('firebase/firestore');
+			const { doc, setDoc } = await import('firebase/firestore');
+			
+			// Create a test parameter if simulation.variables doesn't exist
+			if (!simulation.variables) {
+				simulation.variables = {};
+			}
+			
+			// Create a test parameter ID or use an existing one
+			const testParamId = Object.keys(simulation.variables)[0] || 'test_param_' + Date.now();
+			
+			// Define test data
+			const testData = {
+				name: 'Test Parameter ' + Date.now(), 
+				title: 'Test Description', 
+				initialValue: '42'
+			};
+			
+			console.log('Updating parameter:', testParamId, testData);
+			
+			// Try direct Firebase update
+			const paramRef = doc(db, `simulations/${simulation.id}/variables`, testParamId);
+			await setDoc(paramRef, testData, { merge: true });
+			
+			console.log('Direct parameter update successful!');
+			
+			// Also try with the updateVariable function for comparison
+			const { updateVariable } = await import('simulations/variables/functions');
+			await updateVariable(simulation.id, 'test_param_2_' + Date.now(), {
+				name: 'Test Parameter 2',
+				title: 'Another Test',
+				initialValue: '99'
+			});
+			
+			console.log('Update via updateVariable successful!');
+			
+			alert('Test parameter update successful! Check the console for details.');
+		} catch (error) {
+			console.error('Error during test parameter update:', error);
+			alert('Error during test: ' + error.message);
+		}
+	};
+
 	return <>
 		<h4>Geplante Änderungen</h4>
 		<p>Die Datei ist hochgeladen und ausgewertet worden. Wenn sie umgesetzt wird, werden die folgenden Änderungen auf diese Simulation angewendet. (Geringfügige Änderungen wie z. B. Textänderungen werden hier nicht angezeigt.)</p>
 		<ul>
 			<FolderChanges {...{ simulation, processedWorkbook }} />
 			<PageChanges {...{ simulation, processedWorkbook }} />
+			<ParameterChanges {...{ simulation, processedWorkbook }} />
 		</ul>
 		<p>Möchten Sie diese Änderungen durchführen?</p>
 		<Button variant="contained" onClick={() => {
@@ -99,6 +147,16 @@ function ProcessedWorkbookReport({ simulation, processedWorkbook, setWorkbook, s
 			setWorkbook()
 			setApplied(true) // Show the success note.
 		}}>Änderungen durchführen</Button>
+		
+		{/* Add test button for debugging */}
+		<Button 
+			variant="outlined" 
+			color="secondary" 
+			onClick={testParameterUpdate} 
+			sx={{ ml: 2 }}
+		>
+			Test Parameter Update
+		</Button>
 	</>
 }
 
@@ -145,4 +203,59 @@ function PageChanges({ simulation, processedWorkbook }) {
 	if (numAdded === 0 && numUpdated === 0 && numRemoved === 0)
 		return <li style={{ opacity: 0.4 }}>Es werden keine Seiten hinzugefügt, geändert oder entfernt.</li>
 	return <li>Für die Seiten: {numAdded === 1 ? 'eine Seite wird' : `${numAdded} Seiten werden`} hinzugefügt, {numUpdated === 1 ? 'eine Seite wird' : `${numUpdated} Seiten werden`} aktualisiert und {numRemoved === 1 ? 'eine Seite wird' : `${numRemoved} Seiten werden`} entfernt.</li>
+}
+
+function ParameterChanges({ simulation, processedWorkbook }) {
+	// If there's no parameters data, show that no parameters will be changed
+	if (!processedWorkbook.parameters || !processedWorkbook.parameterList || processedWorkbook.parameterList.length === 0) {
+		return <li style={{ opacity: 0.4 }}>Es werden keine Parameter hinzugefügt, geändert oder entfernt.</li>
+	}
+	
+	// Calculate additions/updates/deletions
+	const newParams = (processedWorkbook.parameterList || [])
+		.filter(newParam => !simulation.variables || !simulation.variables[newParam.id])
+		
+	const updatedParams = (processedWorkbook.parameterList || [])
+		.filter(newParam => {
+			const oldParam = simulation.variables?.[newParam.id]
+			if (!oldParam) {
+				return false // The parameter is new, so it didn't change
+			}
+			
+			// Check if any attribute has changed
+			return ['name', 'title', 'initialValue', 'minValue', 'maxValue'].some(key => {
+				// Handle undefined values properly
+				const oldValue = oldParam[key] || ''
+				const newValue = newParam[key] || ''
+				return oldValue !== newValue
+			})
+		})
+		
+	const removedParams = Object.values(simulation.variables || {})
+		.filter(oldParam => !processedWorkbook.parameters || !processedWorkbook.parameters[oldParam.id])
+		
+	const numAdded = newParams.length
+	const numUpdated = updatedParams.length
+	const numRemoved = removedParams.length
+	
+	// Debug logging
+	console.log("Parameter changes:", {
+		added: newParams.map(p => p.name),
+		updated: updatedParams.map(p => p.name),
+		removed: removedParams.map(p => p.name)
+	})
+		
+	// Show the statistics
+	if (numAdded === 0 && numUpdated === 0 && numRemoved === 0) {
+		return <li style={{ opacity: 0.4 }}>Es werden keine Parameter hinzugefügt, geändert oder entfernt.</li>
+	}
+	
+	return <li>
+		Für die Parameter: {numAdded === 1 ? 'ein Parameter wird' : `${numAdded} Parameter werden`} hinzugefügt
+		{numAdded > 0 && <span> ({newParams.map(p => p.name || '[kein Name]').join(', ')})</span>}, 
+		{numUpdated === 1 ? 'ein Parameter wird' : `${numUpdated} Parameter werden`} aktualisiert
+		{numUpdated > 0 && <span> ({updatedParams.map(p => p.name || '[kein Name]').join(', ')})</span>}, und 
+		{numRemoved === 1 ? 'ein Parameter wird' : `${numRemoved} Parameter werden`} entfernt
+		{numRemoved > 0 && <span> ({removedParams.map(p => p.name || '[kein Name]').join(', ')})</span>}.
+	</li>
 }

--- a/src/pages/simulations/Edit/import/Upload.jsx
+++ b/src/pages/simulations/Edit/import/Upload.jsx
@@ -126,7 +126,18 @@ function PageChanges({ simulation, processedWorkbook }) {
 		const oldPage = simulation.pages[newPage.id]
 		if (!oldPage)
 			return false // The page is new, so it didn't change.
-		return Object.keys(selectAttributes(newPage, ['title', 'description'])).some(key => oldPage[key] !== newPage[key]) // Some attribute in the page changed.
+		
+		// Check if basic attributes have changed
+		const basicAttributesChanged = Object.keys(selectAttributes(newPage, ['title', 'description'])).some(key => oldPage[key] !== newPage[key]);
+		
+		// Check if options have changed
+		const oldOptions = oldPage.options || [];
+		const newOptions = newPage.options || [];
+		const optionsChanged = 
+			oldOptions.length !== newOptions.length || 
+			JSON.stringify(oldOptions) !== JSON.stringify(newOptions);
+		
+		return basicAttributesChanged || optionsChanged;
 	}).length
 	const numRemoved = Object.values(simulation.pages).filter(oldPage => oldPage.type === 'page' && !processedWorkbook.pages[oldPage.id]).length
 

--- a/src/pages/simulations/Edit/import/util/applying.js
+++ b/src/pages/simulations/Edit/import/util/applying.js
@@ -4,10 +4,12 @@ import { selectAttributes, removeUndefineds } from 'util'
 import { markdownToHtml } from './markdown'
 
 import { updateSimulation, updatePage, deletePage } from 'simulations'
+import { updateVariable, deleteVariable } from 'simulations/variables/functions'
 
 // applyChanges takes a simulation and an Excel workbook and applies the changes from that workbook into the Excel file.
 export async function applyChanges(simulation, processedWorkbook) {
 	await applyFolderAndPageChanges(simulation, processedWorkbook)
+	await applyParameterChanges(simulation, processedWorkbook)
 }
 
 // applyFolderAndPageChanges applies all changes for folders and pages. It first adds folders/pages, then updates the main simulation contents, and finally removes pages/folders. By doing it in this order, any simulation that receives updates will not get a completely faulty simulation state, reducing crashes.
@@ -36,7 +38,13 @@ async function applyFolderAndPageChanges(simulation, processedWorkbook) {
 			data.options = data.options.split('\n')
 				.filter(line => line.trim()) // Remove empty lines
 				.map(line => {
-					const [description, feedback, followUpPage] = line.split('|')
+					// Split by pipe character, but handle the case where some fields might be empty
+					const parts = line.split('|')
+					const description = parts[0] || ''
+					const feedback = parts[1] || ''
+					const followUpPage = parts[2] || ''
+					const updateScript = parts[3] || ''
+					
 					const option = {}
 					
 					if (description) {
@@ -48,6 +56,14 @@ async function applyFolderAndPageChanges(simulation, processedWorkbook) {
 					if (followUpPage) {
 						option.followUpPage = followUpPage
 					}
+					if (updateScript) {
+						option.updateScript = updateScript
+					}
+					
+					console.log("Processed option:", {
+						description: description.substring(0, 20) + (description.length > 20 ? '...' : ''),
+						hasUpdateScript: !!updateScript
+					})
 					
 					return option
 				})
@@ -67,4 +83,92 @@ async function applyFolderAndPageChanges(simulation, processedWorkbook) {
 	// Delete old folders.
 	const foldersToRemove = Object.values(simulation.pages).filter(oldFolder => oldFolder.type === 'folder' && !processedWorkbook.folders[oldFolder.id])
 	await Promise.all(foldersToRemove.map(folder => deletePage(simulation, folder)))
+}
+
+// applyParameterChanges applies all changes for parameters/variables. It adds new parameters, updates existing ones, and removes deleted ones.
+async function applyParameterChanges(simulation, processedWorkbook) {
+	const { parameters, parameterList } = processedWorkbook
+	
+	// If no parameters data is available, don't try to update anything
+	if (!parameters || !parameterList || parameterList.length === 0) {
+		console.log("No parameters to update")
+		return
+	}
+	
+	// Make sure simulation.variables exists
+	if (!simulation.variables) {
+		simulation.variables = {}
+	}
+	
+	console.log("Processing parameters:", parameterList.length)
+	
+	// Update existing parameters and add new ones
+	try {
+		// Import Firebase directly to ensure we have access
+		const { doc, setDoc } = await import('firebase/firestore')
+		const { db } = await import('fb')
+		
+		// Use Promise.all to process all parameters in parallel
+		await Promise.all(parameterList.map(async parameter => {
+			// Make sure we have all required fields
+			const data = {
+				name: parameter.name || '',
+				title: parameter.title || '',
+				initialValue: parameter.initialValue || '0',
+			}
+			
+			// Add optional fields if they exist
+			if (parameter.minValue !== undefined && parameter.minValue !== null && parameter.minValue !== '') {
+				data.minValue = parameter.minValue
+			}
+			
+			if (parameter.maxValue !== undefined && parameter.maxValue !== null && parameter.maxValue !== '') {
+				data.maxValue = parameter.maxValue
+			}
+			
+			// Log the update for debugging
+			console.log("Updating parameter using direct Firebase:", parameter.id, data)
+			
+			// Update the parameter in the database directly using Firebase
+			try {
+				// Create a reference to the parameter document
+				const paramRef = doc(db, `simulations/${simulation.id}/variables`, parameter.id)
+				
+				// Use setDoc with merge: true to create if not exists or update if exists
+				await setDoc(paramRef, data, { merge: true })
+				
+				console.log(`Parameter ${parameter.id} updated successfully!`)
+				return Promise.resolve()
+			} catch (error) {
+				console.error("Error updating parameter with direct Firebase:", parameter.id, error)
+				// Continue with other parameters instead of throwing
+				return Promise.resolve()
+			}
+		}))
+	} catch (error) {
+		console.error("Error in parameter batch update:", error)
+	}
+	
+	// Delete old parameters - continue to use deleteVariable as it's simpler
+	try {
+		const parametersToRemove = Object.values(simulation.variables || {})
+			.filter(oldParam => !parameters[oldParam.id])
+			
+		if (parametersToRemove.length > 0) {
+			console.log("Removing parameters:", parametersToRemove.length, 
+				parametersToRemove.map(p => p.name || p.id).join(', '))
+			
+			await Promise.all(parametersToRemove.map(async param => {
+				try {
+					return await deleteVariable(simulation, param)
+				} catch (error) {
+					console.error("Error deleting parameter:", param.id, error)
+					// Continue with other parameters instead of throwing
+					return Promise.resolve()
+				}
+			}))
+		}
+	} catch (error) {
+		console.error("Error in parameter deletion:", error)
+	}
 }

--- a/src/pages/simulations/Edit/import/util/applying.js
+++ b/src/pages/simulations/Edit/import/util/applying.js
@@ -1,6 +1,7 @@
 import { deleteField } from 'firebase/firestore'
 
-import { selectAttributes, removeUndefineds, toHtml } from 'util'
+import { selectAttributes, removeUndefineds } from 'util'
+import { markdownToHtml } from './markdown'
 
 import { updateSimulation, updatePage, deletePage } from 'simulations'
 
@@ -24,8 +25,8 @@ async function applyFolderAndPageChanges(simulation, processedWorkbook) {
 	// Update existing pages and add new ones.
 	await Promise.all(pageList.map(folder => {
 		const data = removeUndefineds(selectAttributes(folder, ['title', 'description']), deleteField())
-		if (data.description) // Ensure that the description is in HTML.
-			data.description = toHtml(data.description)
+		if (data.description) // Convert Markdown to HTML
+			data.description = markdownToHtml(data.description)
 		data.type = 'page'
 		updatePage(simulation.id, folder.id, data, true)
 	}))

--- a/src/pages/simulations/Edit/import/util/applying.js
+++ b/src/pages/simulations/Edit/import/util/applying.js
@@ -24,9 +24,35 @@ async function applyFolderAndPageChanges(simulation, processedWorkbook) {
 
 	// Update existing pages and add new ones.
 	await Promise.all(pageList.map(folder => {
-		const data = removeUndefineds(selectAttributes(folder, ['title', 'description']), deleteField())
-		if (data.description) // Convert Markdown to HTML
+		const data = removeUndefineds(selectAttributes(folder, ['title', 'description', 'options']), deleteField())
+		
+		// Convert description from Markdown to HTML
+		if (data.description) {
 			data.description = markdownToHtml(data.description)
+		}
+
+		// Parse options if they exist
+		if (data.options) {
+			data.options = data.options.split('\n')
+				.filter(line => line.trim()) // Remove empty lines
+				.map(line => {
+					const [description, feedback, followUpPage] = line.split('|')
+					const option = {}
+					
+					if (description) {
+						option.description = markdownToHtml(description)
+					}
+					if (feedback) {
+						option.feedback = markdownToHtml(feedback)
+					}
+					if (followUpPage) {
+						option.followUpPage = followUpPage
+					}
+					
+					return option
+				})
+		}
+
 		data.type = 'page'
 		updatePage(simulation.id, folder.id, data, true)
 	}))

--- a/src/pages/simulations/Edit/import/util/generating.js
+++ b/src/pages/simulations/Edit/import/util/generating.js
@@ -51,11 +51,20 @@ export function addPages(workbook, simulation) {
 
 	// Set up the sheet contents.
 	simulation.pageList.forEach(page => {
+		// Convert options to pipe-separated format
+		const optionsText = (page.options || []).map(option => {
+			const description = option.description ? htmlToMarkdown(option.description) : ''
+			const feedback = option.feedback ? htmlToMarkdown(option.feedback) : ''
+			const followUpPage = option.followUpPage || ''
+			return `${description}|${feedback}|${followUpPage}`
+		}).join('\n')
+
 		worksheet.addRow({
 			id: page.id,
 			parent: page.parent?.id,
 			title: page.title,
 			description: page.description ? htmlToMarkdown(page.description) : '',
+			options: optionsText,
 		})
 	})
 	adjustColumnWidths(worksheet, minColumnWidth, maxColumnWidth)

--- a/src/pages/simulations/Edit/import/util/generating.js
+++ b/src/pages/simulations/Edit/import/util/generating.js
@@ -1,6 +1,7 @@
 import ExcelJS from 'exceljs'
 
 import { hasFolders } from '../../../util'
+import { htmlToMarkdown } from './markdown'
 
 import { tabNames, headers, minColumnWidth, maxColumnWidth } from './settings'
 import { addWorksheet, adjustColumnWidths } from './writing'
@@ -54,7 +55,7 @@ export function addPages(workbook, simulation) {
 			id: page.id,
 			parent: page.parent?.id,
 			title: page.title,
-			description: page.description,
+			description: page.description ? htmlToMarkdown(page.description) : '',
 		})
 	})
 	adjustColumnWidths(worksheet, minColumnWidth, maxColumnWidth)

--- a/src/pages/simulations/Edit/import/util/generating.js
+++ b/src/pages/simulations/Edit/import/util/generating.js
@@ -10,6 +10,7 @@ import { addWorksheet, adjustColumnWidths } from './writing'
 export function generateSimulationWorkbook(simulation) {
 	let workbook = new ExcelJS.Workbook()
 	addPages(workbook, simulation)
+	addParameters(workbook, simulation)
 	return workbook
 }
 
@@ -56,7 +57,8 @@ export function addPages(workbook, simulation) {
 			const description = option.description ? htmlToMarkdown(option.description) : ''
 			const feedback = option.feedback ? htmlToMarkdown(option.feedback) : ''
 			const followUpPage = option.followUpPage || ''
-			return `${description}|${feedback}|${followUpPage}`
+			const updateScript = option.updateScript || ''
+			return `${description}|${feedback}|${followUpPage}|${updateScript}`
 		}).join('\n')
 
 		worksheet.addRow({
@@ -67,5 +69,30 @@ export function addPages(workbook, simulation) {
 			options: optionsText,
 		})
 	})
+	adjustColumnWidths(worksheet, minColumnWidth, maxColumnWidth)
+}
+
+// addParameters takes a simulation workbook and adds a tab for all parameters/variables.
+export function addParameters(workbook, simulation) {
+	// If there are no variables, don't add the tab
+	if (!simulation.variables || Object.keys(simulation.variables).length === 0) {
+		return
+	}
+	
+	// Set up a tab for the parameters and add headers
+	const worksheet = addWorksheet(workbook, tabNames.parameters, headers.parameters)
+	
+	// Add all parameters to the worksheet
+	Object.values(simulation.variables).forEach(variable => {
+		worksheet.addRow({
+			id: variable.id,
+			name: variable.name || '',
+			description: variable.title || '',
+			defaultValue: variable.initialValue || '',
+			minValue: variable.minValue || '',
+			maxValue: variable.maxValue || '',
+		})
+	})
+	
 	adjustColumnWidths(worksheet, minColumnWidth, maxColumnWidth)
 }

--- a/src/pages/simulations/Edit/import/util/index.js
+++ b/src/pages/simulations/Edit/import/util/index.js
@@ -6,3 +6,4 @@ export * from './reading' // General tools (not simulation-specific) to read Exc
 export * from './WorkbookError' // User-friendly rendering of errors provided by the checking scripts.
 export * from './processing' // Tools that turn an Excel file into a more processed format.
 export * from './applying' // Tools that apply a processed workbook to the database.
+export * from './markdown' // Tools for converting between HTML and Markdown

--- a/src/pages/simulations/Edit/import/util/markdown.js
+++ b/src/pages/simulations/Edit/import/util/markdown.js
@@ -1,0 +1,41 @@
+import TurndownService from 'turndown'
+import showdown from 'showdown'
+
+// Configure Turndown for HTML to Markdown conversion
+const turndownService = new TurndownService({
+    headingStyle: 'atx',
+    hr: '---',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*'
+})
+
+// Configure Showdown for Markdown to HTML conversion
+const showdownConverter = new showdown.Converter({
+    tables: true,
+    tasklists: true,
+    strikethrough: true,
+    ghCodeBlocks: true,
+    emoji: true,
+    underline: true,
+    ghMentions: true,
+    ghMentionsLink: 'https://github.com/{u}',
+    parseImgDimensions: true,
+    simplifiedAutoLink: true,
+    excludeTrailingPunctuationFromURLs: true,
+    literalMidWordUnderscores: true,
+    literalMidWordAsterisks: true,
+    splitAdjacentBlockquotes: true
+})
+
+// Convert HTML to Markdown
+export function htmlToMarkdown(html) {
+    if (!html) return ''
+    return turndownService.turndown(html)
+}
+
+// Convert Markdown to HTML
+export function markdownToHtml(markdown) {
+    if (!markdown) return ''
+    return showdownConverter.makeHtml(markdown)
+} 

--- a/src/pages/simulations/Edit/import/util/processing.js
+++ b/src/pages/simulations/Edit/import/util/processing.js
@@ -21,7 +21,8 @@ export function processWorkbook(workbook, simulation) {
 export function processWorkbookInner(workbook) {
 	const folderData = processFolders(workbook)
 	const pageData = processPages(workbook, folderData)
-	return { ...folderData, ...pageData }
+	const parameterData = processParameters(workbook)
+	return { ...folderData, ...pageData, ...parameterData }
 }
 
 // processFolders takes a workbook and comes up with a data structure for the folders.
@@ -108,6 +109,86 @@ function processPages(workbook, folderData) {
 
 	// Return all derived parameters.
 	return { pages, pageList, pageIds, mainPages }
+}
+
+// processParameters puts the parameters/variables provided in the Excel file into a more manageable format.
+function processParameters(workbook) {
+	try {
+		const rawParameters = readSheet(workbook, 'parameters')
+		
+		// If no parameters tab or empty, return empty structure
+		if (!rawParameters || rawParameters.length === 0) {
+			return { parameters: {}, parameterList: [] }
+		}
+		
+		// Walk through the parameters to process their data
+		const parameters = {}
+		const parameterList = rawParameters.map(rawParameter => {
+			// Extract all needed fields from the raw data and ensure proper formatting
+			const parameter = {
+				id: rawParameter.id || getId(),
+				name: rawParameter.name || '',
+				title: rawParameter.description || rawParameter.title || '', // Accept either description or title
+				initialValue: rawParameter.defaultValue || rawParameter.initialValue || '0', // Accept either defaultValue or initialValue
+			}
+			
+			// Add optional fields if they exist - ensure they're strings
+			if (rawParameter.minValue !== undefined && rawParameter.minValue !== null && rawParameter.minValue !== '') {
+				parameter.minValue = String(rawParameter.minValue)
+			}
+			
+			if (rawParameter.maxValue !== undefined && rawParameter.maxValue !== null && rawParameter.maxValue !== '') {
+				parameter.maxValue = String(rawParameter.maxValue)
+			}
+			
+			// Add to parameters object
+			parameters[parameter.id] = parameter
+			return parameter
+		})
+		
+		// Debug logging
+		console.log("Processed parameters:", parameterList.map(p => ({ 
+			id: p.id, 
+			name: p.name, 
+			title: p.title, 
+			initialValue: p.initialValue 
+		})))
+		
+		// Check for duplicate IDs
+		const duplicateId = parameterList.find((param, index) => 
+			parameterList.some((otherParam, otherIndex) => 
+				index < otherIndex && param.id === otherParam.id))?.id
+				
+		if (duplicateId) {
+			throw new ProcessingError({ type: 'duplicateId', tab: 'parameters', id: duplicateId })
+		}
+		
+		// Check for duplicate names
+		const parametersByName = {}
+		for (const param of parameterList) {
+			if (param.name && parametersByName[param.name]) {
+				throw new ProcessingError({ 
+					type: 'duplicateName', 
+					tab: 'parameters', 
+					name: param.name,
+					firstId: parametersByName[param.name].id,
+					secondId: param.id
+				})
+			}
+			if (param.name) {
+				parametersByName[param.name] = param
+			}
+		}
+		
+		return { parameters, parameterList }
+	} catch (error) {
+		if (error.type === 'missingTab') {
+			// If the parameters tab doesn't exist, just return empty data
+			return { parameters: {}, parameterList: [] }
+		}
+		// Otherwise rethrow the error
+		throw error
+	}
 }
 
 // ensureId takes an ID or row-reference. If it's the latter (so a number) then it attempts to find the ID from the corresponding ID-list. On a failure, an error is thrown. It's useful to add tab-data about the referencing tab (origin) and the referenced tab (destination) which is shown in any potential error message to the user.

--- a/src/pages/simulations/Edit/import/util/processing.js
+++ b/src/pages/simulations/Edit/import/util/processing.js
@@ -82,7 +82,7 @@ function processPages(workbook, folderData) {
 	const pageIds = [] // A look-up array that turns a row index into a folder ID.
 	const mainPages = [] // Which pages are in the main directory?
 	const pageList = rawPages.map((rawPage, index) => {
-		const page = selectAttributes(rawPage, ['id', 'title', 'description'])
+		const page = selectAttributes(rawPage, ['id', 'title', 'description', 'options'])
 		if (!rawPage.id)
 			page.id = getId()
 		pageIds[index] = page.id // Set up the ID look-up.

--- a/src/pages/simulations/Edit/import/util/settings.js
+++ b/src/pages/simulations/Edit/import/util/settings.js
@@ -18,6 +18,7 @@ export const headers = {
 		parent: 'In Ordner',
 		title: 'Titel',
 		description: 'Beschreibung',
+		options: 'Antwortmöglichkeiten (eine pro Zeile, Format: Beschreibung|Rückmeldung|Folgeseite)',
 	},
 }
 

--- a/src/pages/simulations/Edit/import/util/settings.js
+++ b/src/pages/simulations/Edit/import/util/settings.js
@@ -3,6 +3,7 @@ export const tabNames = {
 	// settings: 'Einstellungen',
 	folders: 'Ordner',
 	pages: 'Seiten',
+	parameters: 'Parameter',
 }
 export const tabs = Object.keys(tabNames)
 
@@ -18,7 +19,15 @@ export const headers = {
 		parent: 'In Ordner',
 		title: 'Titel',
 		description: 'Beschreibung',
-		options: 'Antwortmöglichkeiten (eine pro Zeile, Format: Beschreibung|Rückmeldung|Folgeseite)',
+		options: 'Antwortmöglichkeiten (eine pro Zeile, Format: Beschreibung|Rückmeldung|Folgeseite|UpdateScript)',
+	},
+	parameters: {
+		id: 'ID',
+		name: 'Name',
+		description: 'Beschreibung',
+		defaultValue: 'Standardwert',
+		minValue: 'Minimalwert',
+		maxValue: 'Maximalwert',
 	},
 }
 


### PR DESCRIPTION
Hey Hildo!

I, admittedly with some AI help because I'm not well versed in react, made changes to the excel functionality. 


Basically there are three things I changed, as you can see reflected in the three commits. 

After the first commit, the excel export now gives out markdown instead of html, so that it's easier for laymen to identify what's what and change certain things in the excel sheet without having to have knowledge of html. When uploaded, it changes back to html, so that it correctly produces the text.

The second commit adds the answers from questions into the export and import, so that they get correctly identified as questions when uploaded again and not as pure text. 

The third commit implements the parameters into the excel export and import, so that not only do they appear in the parameters section but they also appear under the answers to question, where they were. 


With all three commits combined, an export of a full simulation should now take everything into account and an import of said excel sheet should also upload every part of a simulation.

Best Regards
Benjamin